### PR TITLE
<test>(mock vm file)

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -40,6 +40,15 @@ const config: ForgeConfig = {
               js: './src/main/preload.ts',
             },
           },
+          // 添加测试页面入口点
+          {
+            html: './src/renderer/index.html',
+            js: './src/renderer/test-pages/index.tsx',
+            name: 'test_pages',
+            preload: {
+              js: './src/main/preload.ts',
+            },
+          },
         ],
       },
     }),

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": ".webpack/main",
   "scripts": {
     "start": "chcp 65001 && cross-env NODE_ENV=development electron-forge start",
+    "test": "cross-env NODE_ENV=development TEST_MODE=1 electron-forge start",
     "package": "cross-env NODE_ENV=production electron-forge package",
     "make": "cross-env NODE_ENV=production electron-forge make --target @electron-forge/maker-zip",
     "make-mini": "cross-env NODE_ENV=production MAKE_MINI=true electron-forge make --target @electron-forge/maker-zip",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   "scripts": {
     "start": "chcp 65001 && cross-env NODE_ENV=development electron-forge start",
     "test": "cross-env NODE_ENV=development TEST_MODE=1 electron-forge start",
+    "test-page": "node scripts/start-test-page.js",
+    "test-page:toolbox": "node scripts/start-test-page.js ai-service",
     "package": "cross-env NODE_ENV=production electron-forge package",
     "make": "cross-env NODE_ENV=production electron-forge make --target @electron-forge/maker-zip",
     "make-mini": "cross-env NODE_ENV=production MAKE_MINI=true electron-forge make --target @electron-forge/maker-zip",

--- a/scripts/start-test-page.js
+++ b/scripts/start-test-page.js
@@ -1,0 +1,15 @@
+const { spawn } = require('child_process');
+const path = require('path');
+
+// 获取命令行参数
+const pageName = process.argv[2] || 'hello';
+
+// 启动Electron应用，使用cross-env设置环境变量
+const child = spawn('npx', ['cross-env', 'TEST_PAGE=true', 'TEST_MODE=1', `TEST_PAGE_NAME=${pageName}`, 'electron-forge', 'start'], {
+  stdio: 'inherit',
+  shell: true
+});
+
+child.on('close', (code) => {
+  console.log(`Test page process exited with code ${code}`);
+});

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -22,6 +22,8 @@ import { logDeviceInfo } from './logger/log-device-info';
 // whether you're running in development or production).
 declare const MAIN_WINDOW_WEBPACK_ENTRY: string;
 declare const MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY: string;
+// 添加测试页面入口点声明
+declare const TEST_PAGES_WEBPACK_ENTRY: string;
 
 initLogger();
 
@@ -100,8 +102,12 @@ const createWindow = async () => {
   // 需要等待连接podman
   await initPodman(ipcMain);
 
-  // and load the index.html of the app.
-  mainWindow.loadURL(MAIN_WINDOW_WEBPACK_ENTRY);
+  // 根据环境变量选择加载主页面还是测试页面
+  if (process.env.TEST_PAGE === 'true') {
+    mainWindow.loadURL(TEST_PAGES_WEBPACK_ENTRY);
+  } else {
+    mainWindow.loadURL(MAIN_WINDOW_WEBPACK_ENTRY);
+  }
   initTerminalLog(mainWindow);
 
   // Open the DevTools.

--- a/src/renderer/containers/use-vm/index.mock.tsx
+++ b/src/renderer/containers/use-vm/index.mock.tsx
@@ -1,0 +1,22 @@
+import { ActionName, ServiceName } from '../../../main/cmd/type-info';
+
+// 测试环境的mock版本useVM hook
+export function useVM() {
+  // 测试模式下直接返回模拟的已安装状态
+  return {
+    isPodmanInstalled: true,
+    podmanChecking: false,
+    podmanInfo: '',
+    needResintallPodman: false,
+    isWSLInstalled: true,
+    wslVersion: 'WSL 2',
+    wslChecking: false,
+    wslLoading: false,
+    wslOperation: { action: '', service: '' },
+    handleCmdAction: (action: ActionName, service: ServiceName) => {
+      console.log(`Mock handleCmdAction: ${action} ${service}`);
+    },
+    showRebootModal: false,
+    vTReady: true,
+  };
+}

--- a/src/renderer/pages/hello/index.tsx
+++ b/src/renderer/pages/hello/index.tsx
@@ -16,7 +16,8 @@ import './index.scss';
 import { LeftOutlined, RightOutlined } from '@ant-design/icons';
 import { useTrainingServiceShortcut } from '../../containers/use-training-service-shortcut';
 import { useLogContainer } from '../../containers/backup';
-import { useVM } from '../../containers/use-vm';
+// import { useVM } from '../../containers/use-vm';
+import { useVM } from '@use-vm';
 
 export default function Hello() {
   const trainingServiceShortcut = useTrainingServiceShortcut();

--- a/src/renderer/test-pages/index.tsx
+++ b/src/renderer/test-pages/index.tsx
@@ -1,0 +1,115 @@
+import { createRoot } from 'react-dom/client';
+import { MemoryRouter as Router, Routes, Route } from 'react-router-dom';
+import { App as AntdApp } from 'antd';
+import '@ant-design/v5-patch-for-react-19';
+import '../app.css';
+
+// 导入所有页面组件
+import Hello from '../pages/hello';
+import AiService from '../pages/ai-service';
+import ObsidianApp from '../pages/obsidian-app';
+import ObsidianPlugin from '../pages/obsidian-plugin';
+import WorkspaceManage from '../pages/workspace-manage';
+import TTSConfig from '../pages/tts-config';
+import ASRConfig from '../pages/asr-config';
+import LMService from '../pages/lm-service';
+import ExamplePage from '../pages/example-page';
+import PdfConvert from '../pages/pdf-convert';
+import PdfConfig from '../pages/pdf-config';
+import LLMConfig from '../pages/llm-api-config';
+import VoiceRTCConfig from '../pages/voice-rtc-config';
+
+// 获取页面名称的函数
+function getPageName(): string {
+  // 从环境变量获取页面名称
+  // 注意：在Webpack构建过程中，__TEST_PAGE_NAME__会被替换为实际值
+  // @ts-ignore
+  return __TEST_PAGE_NAME__ || 'hello';
+}
+
+// 创建带完整路由的测试应用
+function TestApp() {
+  // 根据页面名称确定初始路由
+  const pageName = getPageName();
+  let initialPath = '/';
+  
+  // 根据页面名称设置初始路径
+  switch(pageName) {
+    case 'ai-service':
+      initialPath = '/ai-service';
+      break;
+    case 'lm-service':
+      initialPath = '/lm-service';
+      break;
+    case 'llm-api-config':
+      initialPath = '/llm-api-config';
+      break;
+    case 'hello':
+      initialPath = '/hello';
+      break;
+    case 'obsidian-app':
+      initialPath = '/obsidian-app';
+      break;
+    case 'tts-config':
+      initialPath = '/TTS-config';
+      break;
+    case 'asr-config':
+      initialPath = '/ASR-config';
+      break;
+    case 'voice-rtc-config':
+      initialPath = '/VOICE_RTC-config';
+      break;
+    case 'pdf-config':
+      initialPath = '/PDF-config';
+      break;
+    case 'pdf-convert':
+      initialPath = '/pdf-convert';
+      break;
+    case 'obsidian-plugin':
+      initialPath = '/obsidian-plugin/default';
+      break;
+    case 'example-page':
+      initialPath = '/example';
+      break;
+    case 'workspace-manage':
+      initialPath = '/workspace-manage/default';
+      break;
+    default:
+      initialPath = '/';
+  }
+
+  return (
+    <AntdApp>
+      <Router initialEntries={[initialPath]}>
+        <Routes>
+          <Route path="/ai-service" element={<AiService />} />
+          <Route path="/lm-service" element={<LMService />} />
+          <Route path="/llm-api-config" element={<LLMConfig />} />
+          <Route path="/hello" element={<Hello />} />
+          <Route path="/obsidian-app" element={<ObsidianApp />} />
+          <Route path="/TTS-config" element={<TTSConfig />} />
+          <Route path="/ASR-config" element={<ASRConfig />} />
+          <Route path="/VOICE_RTC-config" element={<VoiceRTCConfig />} />
+          <Route path="/PDF-config" element={<PdfConfig />} />
+          <Route path="/pdf-convert" element={<PdfConvert />} />
+          <Route
+            path="/obsidian-plugin/:vaultId"
+            element={<ObsidianPlugin />}
+          />
+          <Route path="/example" element={<ExamplePage />} />
+          <Route path="/workspace-manage/:vaultId" element={<WorkspaceManage />} />
+          <Route index element={<Hello />} />
+        </Routes>
+      </Router>
+    </AntdApp>
+  );
+}
+
+// 页面挂载点
+const container = document.createElement('div');
+container.id = 'root';
+document.body.appendChild(container);
+
+// 渲染应用
+const root = createRoot(container);
+root.render(<TestApp />);

--- a/src/use-vm.d.ts
+++ b/src/use-vm.d.ts
@@ -1,0 +1,23 @@
+import { ActionName, ServiceName } from '../src/main/cmd/type-info';
+
+interface VMHookReturn {
+  isPodmanInstalled: boolean;
+  podmanChecking: boolean;
+  podmanInfo: string;
+  needResintallPodman: boolean;
+  isWSLInstalled: boolean;
+  wslVersion: string;
+  wslChecking: boolean;
+  wslLoading: boolean;
+  wslOperation: {
+    action: string;
+    service: string;
+  };
+  handleCmdAction: (action: ActionName, service: ServiceName) => void;
+  showRebootModal: boolean;
+  vTReady: boolean;
+}
+
+declare module '@use-vm' {
+  export function useVM(): VMHookReturn;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,11 @@
     "resolveJsonModule": true,
     "jsx": "react-jsx",
     "paths": {
-      "*": ["node_modules/*"]
+      "*": ["node_modules/*"],
+      "@use-vm": [
+        "src/renderer/containers/use-vm/index.tsx",
+        "src/renderer/containers/use-vm/index.mock.tsx"
+      ]
     }
   },
   "include": ["src/**/*"]

--- a/webpack.plugins.ts
+++ b/webpack.plugins.ts
@@ -13,5 +13,6 @@ export const plugins = [
   new webpack.DefinePlugin({
     __COMMIT_HASH__: JSON.stringify(commitHash),
     __NPM_PACKAGE_VERSION__: JSON.stringify(process.env.npm_package_version),
+    __TEST_PAGE_NAME__: JSON.stringify(process.env.TEST_PAGE_NAME),
   }),
 ];

--- a/webpack.renderer.config.ts
+++ b/webpack.renderer.config.ts
@@ -7,6 +7,11 @@ import { plugins } from './webpack.plugins';
 rules.push();
 
 export const rendererConfig: Configuration = {
+  entry: {
+    main_window: './src/renderer/index.tsx',
+    // 添加测试页面入口点
+    test_pages: './src/renderer/test-pages/index.tsx'
+  },
   module: {
     rules,
   },

--- a/webpack.renderer.config.ts
+++ b/webpack.renderer.config.ts
@@ -1,10 +1,10 @@
 import type { Configuration } from 'webpack';
+import * as path from 'path';
 
 import { rules } from './webpack.rules';
 import { plugins } from './webpack.plugins';
 
 rules.push();
-
 
 export const rendererConfig: Configuration = {
   module: {
@@ -13,5 +13,11 @@ export const rendererConfig: Configuration = {
   plugins,
   resolve: {
     extensions: ['.js', '.ts', '.jsx', '.tsx', '.css', '.scss', '.svg'],
+    alias: {
+      // 根据环境变量决定是否使用mock版本
+      '@use-vm': process.env.TEST_MODE === '1'
+        ? path.resolve(__dirname, 'src/renderer/containers/use-vm/index.mock.tsx')
+        : path.resolve(__dirname, 'src/renderer/containers/use-vm/index.tsx')
+    }
   },
 };


### PR DESCRIPTION
1. 增加一个NPM 任务，npm run test 该命令将会切换Mock的vm配置，在模拟安装环境下确定交互行为
2. 对原有代码无侵入，仅在webpack中添加一个切换指向的vm file的逻辑 3.
本次改动预期行为为阅读器，工具箱，大模型，学科培训的Button表现为可交互Able状态