### PR TITLE
<test> add unit test sample

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,11 @@
+const { createDefaultPreset } = require("ts-jest");
+
+const tsJestTransformCfg = createDefaultPreset().transform;
+
+/** @type {import("jest").Config} **/
+module.exports = {
+  testEnvironment: "node",
+  transform: {
+    ...tsJestTransformCfg,
+  },
+};

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "make-mini": "cross-env NODE_ENV=production MAKE_MINI=true electron-forge make --target @electron-forge/maker-zip",
     "publish": "cross-env NODE_ENV=production electron-forge publish",
     "lint": "eslint --ext .ts,.tsx .",
-    "lint:fix": "eslint --fix --ext .ts,.tsx ."
+    "lint:fix": "eslint --fix --ext .ts,.tsx .",
+    "test": "jest"
   },
   "keywords": [],
   "author": {
@@ -37,6 +38,7 @@
     "@types/form-data": "^2.2.1",
     "@types/lodash": "^4.17.21",
     "@types/node": "^24.0.15",
+    "@types/jest": "^30.0.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@types/uuid": "^10.0.0",
@@ -63,6 +65,7 @@
     "form-data": "^4.0.4",
     "iconv-lite": "^0.6.3",
     "isomorphic-git": "^1.32.0",
+    "jest": "^30.2.0",
     "node-loader": "^2.1.0",
     "node-polyfill-webpack-plugin": "^4.1.0",
     "path-browserify": "^1.0.1",
@@ -74,6 +77,7 @@
     "style-loader": "^3.3.4",
     "sudo-prompt": "^9.2.1",
     "terser-webpack-plugin": "^5.3.16",
+    "ts-jest": "^29.4.6",
     "ts-loader": "^9.5.2",
     "ts-node": "^10.9.2",
     "typescript": "~4.5.4",

--- a/src/main/exec/__tests__/exec.spec.ts
+++ b/src/main/exec/__tests__/exec.spec.ts
@@ -1,0 +1,21 @@
+/* 
+  预期使用方法：npm test -- src/main/exec/__tests__/exec.spec.ts
+*/
+
+jest.mock('electron', () => ({
+  app: {
+    isPackaged: false, 
+    getPath: jest.fn().mockReturnValue('/mocked/exe/path'),
+    getAppPath: jest.fn().mockReturnValue('/mocked/app/path'),
+  },
+}));
+
+const { Exec } = require('../index');
+
+describe('测试 Exec类 应该可以成功初始化', () => {
+  it('should create an instance', () => {
+    const exec = new Exec();
+    expect(exec).toBeInstanceOf(Exec);
+    expect(typeof exec.exec).toBe('function');
+  });
+});


### PR DESCRIPTION
1. 使用[Electron React Boilerplate](https://electron-react-boilerplate.js.org/)官方推荐测试工具Jest
2. 添加内容：对main中src\main\exec的初始化测试用例
无侵入性，无旧代码改动。
预期目的：单独执行并测试Node环境中接口的行为。

预期使用方法
1. 执行所有测试：npm test
2. 执行单独的测试： npm test -- src/main/exec/__tests__/exec.spec.ts
3. 
预期结果：
``` bash
 PASS  src/main/exec/__tests__/exec.spec.ts (6.558 s)
  测试 Exec类 初始化
    √ should create an instance (6 ms)
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        6.721 s, estimated 7 s
Ran all test suites.
```